### PR TITLE
#12 Fix broken 'Import existing map' for macos/linux zip files

### DIFF
--- a/src/components/app/constants.ts
+++ b/src/components/app/constants.ts
@@ -21,7 +21,7 @@ export const EDITOR_TOASTER = createToaster({
 
 export const SONG_FILE_ACCEPT_TYPE: FileMimeType[] = ["audio/ogg"];
 export const COVER_ART_FILE_ACCEPT_TYPE: FileMimeType[] = ["image/jpeg", "image/png"];
-export const MAP_ARCHIVE_FILE_ACCEPT_TYPE: FileMimeType[] = ["application/x-zip-compressed"];
+export const MAP_ARCHIVE_FILE_ACCEPT_TYPE: FileMimeType[] = ["application/zip", "application/x-zip-compressed", "application/octet-stream"];
 
 export const CHARACTERISTIC_COLLECTION = createListCollection({
 	items: CHARACTERISTICS,


### PR DESCRIPTION
Refactor constants: Reintroduce token import and expand MAP_ARCHIVE_FILE_ACCEPT_TYPE to include additional MIME types to fix the broken "import existing map" functionality.