### PR TITLE
Hotfix: 0.4.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Before you jump the gun, we ask that you first and foremost check the following 
 
 If you issue has already been listed, you're welcome to add a comment if you have any additional context to contribute!
 
-When creating a new issue, please use the corresponding templates to better organize the context surrounding your issue and make it as easy as possible for maintainers to address your issue in a timely manner.
+When creating a new issue, **please use the corresponding templates** to better organize the context surrounding your issue and make it as easy as possible for maintainers to address your issue in a timely manner.
 
 ## For Developers
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "beatmapper",
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"type": "module",
 	"private": true,
 	"packageManager": "yarn@4.9.2",

--- a/src/components/app/forms/create-map.tsx
+++ b/src/components/app/forms/create-map.tsx
@@ -6,7 +6,7 @@ import { gtValue, minLength, number, object, pipe, string, transform } from "val
 
 import { APP_TOASTER, CHARACTERISTIC_COLLECTION, COVER_ART_FILE_ACCEPT_TYPE, DIFFICULTY_COLLECTION, SONG_FILE_ACCEPT_TYPE } from "$/components/app/constants";
 import { Field, FileUpload, useAppForm } from "$/components/ui/compositions";
-import { resolveBeatmapId, resolveSongId } from "$/helpers/song.helpers";
+import { createSongId, resolveBeatmapId } from "$/helpers/song.helpers";
 import { addSong } from "$/store/actions";
 import { useAppDispatch, useAppSelector } from "$/store/hooks";
 import { selectSongIds, selectUsername } from "$/store/selectors";
@@ -62,7 +62,7 @@ function CreateMapForm({ dialog }: Props) {
 				});
 			}
 
-			const songId = resolveSongId({ name: value.name });
+			const songId = createSongId(value);
 			const beatmapId = resolveBeatmapId({ characteristic: value.characteristic, difficulty: value.difficulty });
 
 			// Song IDs must be unique, and song IDs are generated from the name.

--- a/src/components/app/forms/settings/index.tsx
+++ b/src/components/app/forms/settings/index.tsx
@@ -23,7 +23,7 @@ const collection = createListCollection({
 function AppSettings() {
 	return (
 		<Fragment>
-			<Tabs collection={collection} />
+			<Tabs unfocusOnClick collection={collection} />
 		</Fragment>
 	);
 }

--- a/src/components/app/layouts/error-boundary.tsx
+++ b/src/components/app/layouts/error-boundary.tsx
@@ -42,7 +42,7 @@ function ErrorBoundary({ error, interactive = true, reset }: Props) {
 								</Wrap>
 							</Stack>
 							<Text>
-								If you're still encountering issues, please <AnchorLink href="https://github.com/bsmg/beatmapper/issues/new">fill out a bug report</AnchorLink> on the repository.
+								If you're still encountering issues, please <AnchorLink href="https://github.com/bsmg/beatmapper/issues/new?template=bug.md">fill out a bug report</AnchorLink> on the repository.
 							</Text>
 						</Stack>
 					</Presence>

--- a/src/components/app/layouts/status-bar/range.tsx
+++ b/src/components/app/layouts/status-bar/range.tsx
@@ -15,7 +15,7 @@ function StatusBarRangeControl({ label, minIcon, maxIcon, min, max, step, value,
 		<Tooltip render={() => label}>
 			<HStack gap={1}>
 				<StatusBarIcon size={14} icon={minIcon} onClick={() => onValueChange?.({ value: [min ?? 0] })} disabled={disabled} />
-				<Slider {...delegated} size="sm" min={min} max={max} step={step} value={value} onValueChange={onValueChange} disabled={disabled} />
+				<Slider {...delegated} size="sm" min={min} max={max} step={step} value={value} onValueChange={onValueChange} disabled={disabled} unfocusOnClick />
 				<StatusBarIcon size={14} icon={maxIcon} onClick={() => onValueChange?.({ value: [max ?? 100] })} disabled={disabled} />
 			</HStack>
 		</Tooltip>

--- a/src/components/app/layouts/status-bar/toggle.tsx
+++ b/src/components/app/layouts/status-bar/toggle.tsx
@@ -15,7 +15,7 @@ function StatusBarToggleControl({ label, onIcon, offIcon, checked, onCheckedChan
 		<Tooltip render={() => label}>
 			<HStack gap={1}>
 				<StatusBarIcon size={14} opacity={checked ? 0.5 : 1} icon={offIcon} onClick={() => onCheckedChange?.({ checked: false })} disabled={disabled} />
-				<Switch {...rest} size="sm" checked={checked} onCheckedChange={onCheckedChange} disabled={disabled} />
+				<Switch {...rest} size="sm" checked={checked} onCheckedChange={onCheckedChange} disabled={disabled} unfocusOnClick />
 				<StatusBarIcon size={14} opacity={checked ? 1 : 0.5} icon={onIcon} onClick={() => onCheckedChange?.({ checked: true })} disabled={disabled} />
 			</HStack>
 		</Tooltip>

--- a/src/components/app/templates/action-panel-groups/clipboard.tsx
+++ b/src/components/app/templates/action-panel-groups/clipboard.tsx
@@ -22,15 +22,15 @@ function ClipboardActionPanelActionGroup({ sid }: Props) {
 		<ActionPanelGroup.ActionGroup>
 			<Presence asChild present={isAnythingSelected}>
 				<ActionPanelGroup.ActionGroup>
-					<Button variant="subtle" size="sm" disabled={!isAnythingSelected} onClick={() => dispatch(cutSelection({ view: view ?? View.BEATMAP }))}>
+					<Button variant="subtle" size="sm" disabled={!isAnythingSelected} unfocusOnClick onClick={() => dispatch(cutSelection({ view: view ?? View.BEATMAP }))}>
 						Cut
 					</Button>
-					<Button variant="subtle" size="sm" disabled={!isAnythingSelected} onClick={() => dispatch(copySelection({ view: view ?? View.BEATMAP }))}>
+					<Button variant="subtle" size="sm" disabled={!isAnythingSelected} unfocusOnClick onClick={() => dispatch(copySelection({ view: view ?? View.BEATMAP }))}>
 						Copy
 					</Button>
 				</ActionPanelGroup.ActionGroup>
 			</Presence>
-			<Button variant="subtle" size="sm" disabled={!hasCopiedNotes} onClick={() => dispatch(pasteSelection({ songId: sid, view: view ?? View.BEATMAP }))}>
+			<Button variant="subtle" size="sm" disabled={!hasCopiedNotes} unfocusOnClick onClick={() => dispatch(pasteSelection({ songId: sid, view: view ?? View.BEATMAP }))}>
 				Paste Selection
 			</Button>
 		</ActionPanelGroup.ActionGroup>

--- a/src/components/app/templates/action-panel-groups/default.tsx
+++ b/src/components/app/templates/action-panel-groups/default.tsx
@@ -24,18 +24,18 @@ function DefaultActionPanelGroup({ sid, handleGridConfigClick }: Props) {
 			<ClipboardActionPanelActionGroup sid={sid} />
 			<ActionPanelGroup.ActionGroup>
 				<Tooltip render={() => "Select everything over a time period"}>
-					<Button variant="subtle" size="sm" onClick={() => openPrompt("QUICK_SELECT")}>
+					<Button variant="subtle" size="sm" unfocusOnClick onClick={() => openPrompt("QUICK_SELECT")}>
 						Quick-select
 					</Button>
 				</Tooltip>
 				<Tooltip render={() => "Jump to a specific beat number"}>
-					<Button variant="subtle" size="sm" onClick={() => openPrompt("JUMP_TO_BEAT")}>
+					<Button variant="subtle" size="sm" unfocusOnClick onClick={() => openPrompt("JUMP_TO_BEAT")}>
 						Jump to Beat
 					</Button>
 				</Tooltip>
 				{mappingExtensionsEnabled && (
 					<Tooltip render={() => "Change the number of columns/rows"}>
-						<Button variant="subtle" size="sm" onClick={handleGridConfigClick}>
+						<Button variant="subtle" size="sm" unfocusOnClick onClick={handleGridConfigClick}>
 							Customize Grid
 						</Button>
 					</Tooltip>

--- a/src/components/app/templates/action-panel-groups/direction.tsx
+++ b/src/components/app/templates/action-panel-groups/direction.tsx
@@ -20,31 +20,31 @@ function NoteDirectionActionPanelGroup() {
 	return (
 		<ActionPanelGroup.Root label="Notes">
 			<Grid columns={3} gap={0.5}>
-				<Button variant="ghost" size="icon" disabled={isDisabled} data-active={selectedDirection === NoteDirection.UP_LEFT} onClick={() => dispatch(updateNotesEditorDirection({ direction: NoteDirection.UP_LEFT }))}>
+				<Button variant="ghost" size="icon" disabled={isDisabled} data-active={selectedDirection === NoteDirection.UP_LEFT} unfocusOnClick onClick={() => dispatch(updateNotesEditorDirection({ direction: NoteDirection.UP_LEFT }))}>
 					<ArrowUpLeftIcon />
 				</Button>
-				<Button variant="ghost" size="icon" disabled={isDisabled} data-active={selectedDirection === NoteDirection.UP} onClick={() => dispatch(updateNotesEditorDirection({ direction: NoteDirection.UP }))}>
+				<Button variant="ghost" size="icon" disabled={isDisabled} data-active={selectedDirection === NoteDirection.UP} unfocusOnClick onClick={() => dispatch(updateNotesEditorDirection({ direction: NoteDirection.UP }))}>
 					<ArrowUpIcon />
 				</Button>
-				<Button variant="ghost" size="icon" disabled={isDisabled} data-active={selectedDirection === NoteDirection.UP_RIGHT} onClick={() => dispatch(updateNotesEditorDirection({ direction: NoteDirection.UP_RIGHT }))}>
+				<Button variant="ghost" size="icon" disabled={isDisabled} data-active={selectedDirection === NoteDirection.UP_RIGHT} unfocusOnClick onClick={() => dispatch(updateNotesEditorDirection({ direction: NoteDirection.UP_RIGHT }))}>
 					<ArrowUpRightIcon />
 				</Button>
-				<Button variant="ghost" size="icon" disabled={isDisabled} data-active={selectedDirection === NoteDirection.LEFT} onClick={() => dispatch(updateNotesEditorDirection({ direction: NoteDirection.LEFT }))}>
+				<Button variant="ghost" size="icon" disabled={isDisabled} data-active={selectedDirection === NoteDirection.LEFT} unfocusOnClick onClick={() => dispatch(updateNotesEditorDirection({ direction: NoteDirection.LEFT }))}>
 					<ArrowLeftIcon />
 				</Button>
-				<Button variant="ghost" size="icon" disabled={isDisabled} data-active={selectedDirection === NoteDirection.ANY} onClick={() => dispatch(updateNotesEditorDirection({ direction: NoteDirection.ANY }))}>
+				<Button variant="ghost" size="icon" disabled={isDisabled} data-active={selectedDirection === NoteDirection.ANY} unfocusOnClick onClick={() => dispatch(updateNotesEditorDirection({ direction: NoteDirection.ANY }))}>
 					<CircleIcon />
 				</Button>
-				<Button variant="ghost" size="icon" disabled={isDisabled} data-active={selectedDirection === NoteDirection.RIGHT} onClick={() => dispatch(updateNotesEditorDirection({ direction: NoteDirection.RIGHT }))}>
+				<Button variant="ghost" size="icon" disabled={isDisabled} data-active={selectedDirection === NoteDirection.RIGHT} unfocusOnClick onClick={() => dispatch(updateNotesEditorDirection({ direction: NoteDirection.RIGHT }))}>
 					<ArrowRightIcon />
 				</Button>
-				<Button variant="ghost" size="icon" disabled={isDisabled} data-active={selectedDirection === NoteDirection.DOWN_LEFT} onClick={() => dispatch(updateNotesEditorDirection({ direction: NoteDirection.DOWN_LEFT }))}>
+				<Button variant="ghost" size="icon" disabled={isDisabled} data-active={selectedDirection === NoteDirection.DOWN_LEFT} unfocusOnClick onClick={() => dispatch(updateNotesEditorDirection({ direction: NoteDirection.DOWN_LEFT }))}>
 					<ArrowDownLeftIcon />
 				</Button>
-				<Button variant="ghost" size="icon" disabled={isDisabled} data-active={selectedDirection === NoteDirection.DOWN} onClick={() => dispatch(updateNotesEditorDirection({ direction: NoteDirection.DOWN }))}>
+				<Button variant="ghost" size="icon" disabled={isDisabled} data-active={selectedDirection === NoteDirection.DOWN} unfocusOnClick onClick={() => dispatch(updateNotesEditorDirection({ direction: NoteDirection.DOWN }))}>
 					<ArrowDownIcon />
 				</Button>
-				<Button variant="ghost" size="icon" disabled={isDisabled} data-active={selectedDirection === NoteDirection.DOWN_RIGHT} onClick={() => dispatch(updateNotesEditorDirection({ direction: NoteDirection.DOWN_RIGHT }))}>
+				<Button variant="ghost" size="icon" disabled={isDisabled} data-active={selectedDirection === NoteDirection.DOWN_RIGHT} unfocusOnClick onClick={() => dispatch(updateNotesEditorDirection({ direction: NoteDirection.DOWN_RIGHT }))}>
 					<ArrowDownRightIcon />
 				</Button>
 			</Grid>

--- a/src/components/app/templates/action-panel-groups/history.tsx
+++ b/src/components/app/templates/action-panel-groups/history.tsx
@@ -15,10 +15,10 @@ function HistoryActionPanelActionGroup({ sid }: Props) {
 
 	return (
 		<ActionPanelGroup.ActionGroup>
-			<Button variant="subtle" size="sm" disabled={!canUndo} onClick={() => dispatch(undoObjects({ songId: sid }))}>
+			<Button variant="subtle" size="sm" disabled={!canUndo} unfocusOnClick onClick={() => dispatch(undoObjects({ songId: sid }))}>
 				Undo
 			</Button>
-			<Button variant="subtle" size="sm" disabled={!canRedo} onClick={() => dispatch(redoObjects({ songId: sid }))}>
+			<Button variant="subtle" size="sm" disabled={!canRedo} unfocusOnClick onClick={() => dispatch(redoObjects({ songId: sid }))}>
 				Redo
 			</Button>
 		</ActionPanelGroup.ActionGroup>

--- a/src/components/app/templates/action-panel-groups/obstacles.tsx
+++ b/src/components/app/templates/action-panel-groups/obstacles.tsx
@@ -12,7 +12,7 @@ function ObstaclesActionPanelGroup({ sid }: Props) {
 	return (
 		<ActionPanelGroup.Root label="Obstacles">
 			<ActionPanelGroup.ActionGroup>
-				<Button variant="subtle" size="sm" onClick={() => openPrompt("UPDATE_OBSTACLE_DURATION")}>
+				<Button variant="subtle" size="sm" unfocusOnClick onClick={() => openPrompt("UPDATE_OBSTACLE_DURATION")}>
 					Change duration
 				</Button>
 			</ActionPanelGroup.ActionGroup>

--- a/src/components/app/templates/action-panel-groups/tool.tsx
+++ b/src/components/app/templates/action-panel-groups/tool.tsx
@@ -20,22 +20,22 @@ function NoteToolActionPanelGroup({ sid, bid }: Props) {
 		<ActionPanelGroup.Root label="Items">
 			<ActionPanelGroup.ActionGroup>
 				<Tooltip render={() => "Left Color Note"}>
-					<Button variant="ghost" size="icon" data-active={selectedTool === ObjectTool.LEFT_NOTE} onClick={() => dispatch(updateNotesEditorTool({ tool: ObjectTool.LEFT_NOTE }))}>
+					<Button variant="ghost" size="icon" data-active={selectedTool === ObjectTool.LEFT_NOTE} unfocusOnClick onClick={() => dispatch(updateNotesEditorTool({ tool: ObjectTool.LEFT_NOTE }))}>
 						<ColorNoteIcon size={20} color={resolveColorForItem(ObjectTool.LEFT_NOTE, { customColors: colorScheme })} />
 					</Button>
 				</Tooltip>
 				<Tooltip render={() => "Right Color Note"}>
-					<Button variant="ghost" size="icon" data-active={selectedTool === ObjectTool.RIGHT_NOTE} onClick={() => dispatch(updateNotesEditorTool({ tool: ObjectTool.RIGHT_NOTE }))}>
+					<Button variant="ghost" size="icon" data-active={selectedTool === ObjectTool.RIGHT_NOTE} unfocusOnClick onClick={() => dispatch(updateNotesEditorTool({ tool: ObjectTool.RIGHT_NOTE }))}>
 						<ColorNoteIcon size={20} color={resolveColorForItem(ObjectTool.RIGHT_NOTE, { customColors: colorScheme })} />
 					</Button>
 				</Tooltip>
 				<Tooltip render={() => "Bomb Note"}>
-					<Button variant="ghost" size="icon" data-active={selectedTool === ObjectTool.BOMB_NOTE} onClick={() => dispatch(updateNotesEditorTool({ tool: ObjectTool.BOMB_NOTE }))}>
+					<Button variant="ghost" size="icon" data-active={selectedTool === ObjectTool.BOMB_NOTE} unfocusOnClick onClick={() => dispatch(updateNotesEditorTool({ tool: ObjectTool.BOMB_NOTE }))}>
 						<BombNoteIcon size={20} />
 					</Button>
 				</Tooltip>
 				<Tooltip render={() => "Obstacle"}>
-					<Button variant="ghost" size="icon" data-active={selectedTool === ObjectTool.OBSTACLE} onClick={() => dispatch(updateNotesEditorTool({ tool: ObjectTool.OBSTACLE }))}>
+					<Button variant="ghost" size="icon" data-active={selectedTool === ObjectTool.OBSTACLE} unfocusOnClick onClick={() => dispatch(updateNotesEditorTool({ tool: ObjectTool.OBSTACLE }))}>
 						<ObstacleIcon size={20} color={resolveColorForItem(ObjectTool.OBSTACLE, { customColors: colorScheme })} />
 					</Button>
 				</Tooltip>

--- a/src/components/app/templates/editor/action-panel/grid.tsx
+++ b/src/components/app/templates/editor/action-panel/grid.tsx
@@ -30,7 +30,7 @@ function GridActionPanel({ sid, finishTweakingGrid }: Props) {
 			{!isObjectEmpty(gridPresets) && (
 				<ActionPanelGroup.Root label="Grid Presets">
 					<ActionPanelGroup.ActionGroup>
-						<Select collection={createListCollection({ items: Object.keys(gridPresets) })} value={[slot]} onValueChange={(x) => setSlot(x.value[0])} />
+						<Select unfocusOnClick collection={createListCollection({ items: Object.keys(gridPresets) })} value={[slot]} onValueChange={(x) => setSlot(x.value[0])} />
 					</ActionPanelGroup.ActionGroup>
 					<ActionPanelGroup.ActionGroup>
 						<Tooltip render={() => "Load Grid Preset"}>

--- a/src/components/app/templates/editor/action-panel/grid.tsx
+++ b/src/components/app/templates/editor/action-panel/grid.tsx
@@ -34,12 +34,12 @@ function GridActionPanel({ sid, finishTweakingGrid }: Props) {
 					</ActionPanelGroup.ActionGroup>
 					<ActionPanelGroup.ActionGroup>
 						<Tooltip render={() => "Load Grid Preset"}>
-							<Button variant="subtle" size="sm" disabled={!gridPresets[slot]} onClick={() => dispatch(loadGridPreset({ songId: sid, grid: gridPresets[slot] }))}>
+							<Button variant="subtle" size="sm" disabled={!gridPresets[slot]} unfocusOnClick onClick={() => dispatch(loadGridPreset({ songId: sid, grid: gridPresets[slot] }))}>
 								<ArrowUpFromDotIcon size={16} />
 							</Button>
 						</Tooltip>
 						<Tooltip render={() => "Delete Grid Preset"}>
-							<Button variant="subtle" size="sm" disabled={!gridPresets[slot]} onClick={() => dispatch(removeGridPreset({ songId: sid, presetSlot: slot }))}>
+							<Button variant="subtle" size="sm" disabled={!gridPresets[slot]} unfocusOnClick onClick={() => dispatch(removeGridPreset({ songId: sid, presetSlot: slot }))}>
 								<TrashIcon size={16} />
 							</Button>
 						</Tooltip>
@@ -63,13 +63,13 @@ function GridActionPanel({ sid, finishTweakingGrid }: Props) {
 					</Field>
 				</ActionPanelGroup.ActionGroup>
 				<ActionPanelGroup.ActionGroup>
-					<Button variant="subtle" size="sm" onClick={() => openPrompt("SAVE_GRID_PRESET")}>
+					<Button variant="subtle" size="sm" unfocusOnClick onClick={() => openPrompt("SAVE_GRID_PRESET")}>
 						Save as Preset
 					</Button>
-					<Button variant="subtle" size="sm" onClick={() => sid && dispatch(updateGridSize({ songId: sid, changes: DEFAULT_GRID }))}>
+					<Button variant="subtle" size="sm" unfocusOnClick onClick={() => sid && dispatch(updateGridSize({ songId: sid, changes: DEFAULT_GRID }))}>
 						Reset Grid
 					</Button>
-					<Button variant="subtle" size="sm" onClick={finishTweakingGrid}>
+					<Button variant="subtle" size="sm" unfocusOnClick onClick={finishTweakingGrid}>
 						Finish Customizing
 					</Button>
 				</ActionPanelGroup.ActionGroup>

--- a/src/components/app/templates/editor/action-panel/selection.tsx
+++ b/src/components/app/templates/editor/action-panel/selection.tsx
@@ -64,30 +64,30 @@ function SelectionActionPanel({ sid, numOfSelectedBlocks, numOfSelectedMines, nu
 			<ActionPanelGroup.Root label="Actions">
 				<ActionPanelGroup.ActionGroup>
 					<Tooltip render={() => "Mirror selection horizontally"}>
-						<Button variant="ghost" size="icon" onClick={() => dispatch(mirrorSelection({ axis: "horizontal", grid }))}>
+						<Button variant="ghost" size="icon" unfocusOnClick onClick={() => dispatch(mirrorSelection({ axis: "horizontal", grid }))}>
 							<FlipHorizontal2Icon />
 						</Button>
 					</Tooltip>
 					<Tooltip render={() => "Mirror selection vertically"}>
-						<Button variant="ghost" size="icon" onClick={() => dispatch(mirrorSelection({ axis: "vertical", grid }))}>
+						<Button variant="ghost" size="icon" unfocusOnClick onClick={() => dispatch(mirrorSelection({ axis: "vertical", grid }))}>
 							<FlipVertical2Icon />
 						</Button>
 					</Tooltip>
 				</ActionPanelGroup.ActionGroup>
 				<ActionPanelGroup.ActionGroup>
 					<Tooltip render={() => "Nudge selection forwards"}>
-						<Button variant="ghost" size="icon" onClick={() => dispatch(nudgeSelection({ direction: "forwards", view: View.BEATMAP }))}>
+						<Button variant="ghost" size="icon" unfocusOnClick onClick={() => dispatch(nudgeSelection({ direction: "forwards", view: View.BEATMAP }))}>
 							<ArrowUpToLineIcon />
 						</Button>
 					</Tooltip>
 					<Tooltip render={() => "Nudge selection backwards"}>
-						<Button variant="ghost" size="icon" onClick={() => dispatch(nudgeSelection({ direction: "backwards", view: View.BEATMAP }))}>
+						<Button variant="ghost" size="icon" unfocusOnClick onClick={() => dispatch(nudgeSelection({ direction: "backwards", view: View.BEATMAP }))}>
 							<ArrowDownToLineIcon />
 						</Button>
 					</Tooltip>
 				</ActionPanelGroup.ActionGroup>
 				<ActionPanelGroup.ActionGroup>
-					<Button variant="subtle" size="sm" onClick={() => dispatch(deselectAllEntities({ view: View.BEATMAP }))}>
+					<Button variant="subtle" size="sm" unfocusOnClick onClick={() => dispatch(deselectAllEntities({ view: View.BEATMAP }))}>
 						Clear selection
 					</Button>
 				</ActionPanelGroup.ActionGroup>

--- a/src/components/app/templates/editor/navigation-panel/playback.tsx
+++ b/src/components/app/templates/editor/navigation-panel/playback.tsx
@@ -26,24 +26,24 @@ function EditorNavigationControls({ sid }: Props) {
 	return (
 		<Wrapper>
 			<Column>
-				<Select collection={SNAPPING_INCREMENT_LIST_COLLECTION} value={[snapTo.toString()]} onValueChange={(ev) => dispatch(updateSnap({ value: Number.parseFloat(ev.value[0]) }))}>
+				<Select unfocusOnClick collection={SNAPPING_INCREMENT_LIST_COLLECTION} value={[snapTo.toString()]} onValueChange={(ev) => dispatch(updateSnap({ value: Number.parseFloat(ev.value[0]) }))}>
 					Snap To
 				</Select>
 			</Column>
 			<Column>
-				<Button variant="ghost" size="icon" disabled={isLoadingSong} onClick={() => dispatch(jumpToStart({ songId: sid }))}>
+				<Button variant="ghost" size="icon" disabled={isLoadingSong} unfocusOnClick onClick={() => dispatch(jumpToStart({ songId: sid }))}>
 					<SkipBackIcon />
 				</Button>
-				<Button variant="ghost" size="icon" disabled={isLoadingSong} onClick={() => dispatch(seekBackwards({ songId: sid, view }))}>
+				<Button variant="ghost" size="icon" disabled={isLoadingSong} unfocusOnClick onClick={() => dispatch(seekBackwards({ songId: sid, view }))}>
 					<RewindIcon />
 				</Button>
-				<Button variant="ghost" size="icon" disabled={isLoadingSong} onClick={() => dispatch(playButtonAction({ songId: sid }))}>
+				<Button variant="ghost" size="icon" disabled={isLoadingSong} unfocusOnClick onClick={() => dispatch(playButtonAction({ songId: sid }))}>
 					{isPlaying ? <PauseIcon /> : <PlayIcon />}
 				</Button>
-				<Button variant="ghost" size="icon" disabled={isLoadingSong} onClick={() => dispatch(seekForwards({ songId: sid, view }))}>
+				<Button variant="ghost" size="icon" disabled={isLoadingSong} unfocusOnClick onClick={() => dispatch(seekForwards({ songId: sid, view }))}>
 					<FastForwardIcon />
 				</Button>
-				<Button variant="ghost" size="icon" disabled={isLoadingSong} onClick={() => dispatch(jumpToEnd({ songId: sid }))}>
+				<Button variant="ghost" size="icon" disabled={isLoadingSong} unfocusOnClick onClick={() => dispatch(jumpToEnd({ songId: sid }))}>
 					<SkipForwardIcon />
 				</Button>
 			</Column>

--- a/src/components/app/templates/editor/song-info.tsx
+++ b/src/components/app/templates/editor/song-info.tsx
@@ -2,7 +2,7 @@ import type { SelectValueChangeDetails } from "@ark-ui/react/select";
 import { useNavigate } from "@tanstack/react-router";
 import type { CharacteristicName, DifficultyName } from "bsmap/types";
 import { PlusIcon } from "lucide-react";
-import { Fragment, memo, useCallback, useMemo } from "react";
+import { memo, useCallback, useMemo } from "react";
 
 import { CoverArtFilePreview } from "$/components/app/compositions";
 import { createBeatmapListCollection } from "$/components/app/constants";
@@ -52,41 +52,37 @@ function EditorSongInfo({ sid, bid, showDifficultySelector }: Props) {
 	);
 
 	return (
-		<Fragment>
-			<OuterWrapper gap={1.5}>
-				<CoverArtFilePreview songId={sid} width={COVER_ART_SIZES[showDifficultySelector ? "medium" : "small"]} />
-				<Stack gap={1}>
-					<Stack gap={0.5}>
-						<Text color={"fg.default"} fontSize="20px" fontWeight={400} lineHeight={1}>
-							{metadata.title}
-						</Text>
-						<Text color={"fg.muted"} fontSize="16px" fontWeight={400} lineHeight={1}>
-							{metadata.artist}
-						</Text>
-					</Stack>
-					{showDifficultySelector && bid && (
-						<Fragment>
-							<HStack gap={0.5}>
-								<Select size="sm" collection={BEATMAP_LIST_COLLECTION} value={[selectedBeatmap.toString()]} onValueChange={handleBeatmapSelect} />
-								<Dialog
-									title="Create New Beatmap"
-									unmountOnExit
-									render={(ctx) => (
-										<CreateBeatmapForm dialog={ctx} sid={sid} bid={bid} onSubmit={handleCreate}>
-											{() => "Create beatmap"}
-										</CreateBeatmapForm>
-									)}
-								>
-									<Button variant="ghost" size="sm">
-										<PlusIcon size={16} />
-									</Button>
-								</Dialog>
-							</HStack>
-						</Fragment>
-					)}
+		<OuterWrapper gap={1.5}>
+			<CoverArtFilePreview songId={sid} width={COVER_ART_SIZES[showDifficultySelector ? "medium" : "small"]} />
+			<Stack gap={1}>
+				<Stack gap={0.5}>
+					<Text color={"fg.default"} fontSize="20px" fontWeight={400} lineHeight={1}>
+						{metadata.title}
+					</Text>
+					<Text color={"fg.muted"} fontSize="16px" fontWeight={400} lineHeight={1}>
+						{metadata.artist}
+					</Text>
 				</Stack>
-			</OuterWrapper>
-		</Fragment>
+				{showDifficultySelector && bid && (
+					<HStack gap={0.5}>
+						<Select unfocusOnClick size="sm" collection={BEATMAP_LIST_COLLECTION} value={[selectedBeatmap.toString()]} onValueChange={handleBeatmapSelect} />
+						<Dialog
+							title="Create New Beatmap"
+							unmountOnExit
+							render={(ctx) => (
+								<CreateBeatmapForm dialog={ctx} sid={sid} bid={bid} onSubmit={handleCreate}>
+									{() => "Create beatmap"}
+								</CreateBeatmapForm>
+							)}
+						>
+							<Button variant="ghost" size="sm">
+								<PlusIcon size={16} />
+							</Button>
+						</Dialog>
+					</HStack>
+				)}
+			</Stack>
+		</OuterWrapper>
 	);
 }
 

--- a/src/components/app/templates/events/controls.tsx
+++ b/src/components/app/templates/events/controls.tsx
@@ -59,23 +59,23 @@ function EventGridControls({ sid, bid, ...rest }: Props) {
 		<Wrapper {...rest}>
 			<HStack gap={4} justify={"flex-start"}>
 				<Field cosmetic size="sm" label="Edit Mode">
-					<ToggleGroup collection={EDIT_MODE_LIST_COLLECTION} value={[selectedEditMode]} onValueChange={(details) => details.value.length > 0 && dispatch(updateEventsEditorEditMode({ editMode: details.value[0] as EventEditMode }))} />
+					<ToggleGroup collection={EDIT_MODE_LIST_COLLECTION} unfocusOnClick value={[selectedEditMode]} onValueChange={(details) => details.value.length > 0 && dispatch(updateEventsEditorEditMode({ editMode: details.value[0] as EventEditMode }))} />
 				</Field>
 				<Field cosmetic size="sm" label="Light Color">
-					<ToggleGroup collection={COLOR_LIST_COLLECTION} value={[selectedColor]} onValueChange={(details) => details.value.length > 0 && dispatch(updateEventsEditorColor({ color: details.value[0] as EventColor }))} />
+					<ToggleGroup collection={COLOR_LIST_COLLECTION} unfocusOnClick value={[selectedColor]} onValueChange={(details) => details.value.length > 0 && dispatch(updateEventsEditorColor({ color: details.value[0] as EventColor }))} />
 				</Field>
 				<Field cosmetic size="sm" label="Light Effect">
-					<ToggleGroup collection={EFFECT_LIST_COLLECTION} value={[selectedTool]} onValueChange={(details) => details.value.length > 0 && dispatch(updateEventsEditorTool({ tool: details.value[0] as EventTool }))} />
+					<ToggleGroup collection={EFFECT_LIST_COLLECTION} unfocusOnClick value={[selectedTool]} onValueChange={(details) => details.value.length > 0 && dispatch(updateEventsEditorTool({ tool: details.value[0] as EventTool }))} />
 				</Field>
 				<Field cosmetic size="sm" label="Locks">
 					<HStack gap={1}>
 						<Tooltip render={() => "Loop playback within the current event window (L)"}>
-							<Toggle pressed={isLockedToCurrentWindow} onPressedChange={() => dispatch(updateEventsEditorWindowLock())}>
+							<Toggle unfocusOnClick pressed={isLockedToCurrentWindow} onPressedChange={() => dispatch(updateEventsEditorWindowLock())}>
 								<RepeatIcon size={16} />
 							</Toggle>
 						</Tooltip>
 						<Tooltip render={() => "Pair side lasers for symmetrical left/right events"}>
-							<Toggle pressed={areLasersLocked} onPressedChange={() => dispatch(updateEventsEditorMirrorLock())}>
+							<Toggle unfocusOnClick pressed={areLasersLocked} onPressedChange={() => dispatch(updateEventsEditorMirrorLock())}>
 								<LockIcon size={16} />
 							</Toggle>
 						</Tooltip>
@@ -85,10 +85,10 @@ function EventGridControls({ sid, bid, ...rest }: Props) {
 			<HStack gap={4} justify={"flex-end"}>
 				<Field cosmetic size="sm" label="Zoom" align="end">
 					<HStack gap={1}>
-						<Button variant="subtle" size="sm" onClick={() => dispatch(decrementEventsEditorZoom())} disabled={zoomLevel === ZOOM_LEVEL_MIN}>
+						<Button variant="subtle" size="sm" unfocusOnClick onClick={() => dispatch(decrementEventsEditorZoom())} disabled={zoomLevel === ZOOM_LEVEL_MIN}>
 							<ZoomOutIcon size={14} />
 						</Button>
-						<Button variant="subtle" size="sm" onClick={() => dispatch(incrementEventsEditorZoom())} disabled={zoomLevel === ZOOM_LEVEL_MAX}>
+						<Button variant="subtle" size="sm" unfocusOnClick onClick={() => dispatch(incrementEventsEditorZoom())} disabled={zoomLevel === ZOOM_LEVEL_MAX}>
 							<ZoomInIcon size={14} />
 						</Button>
 					</HStack>

--- a/src/components/app/templates/shortcuts/default.tsx
+++ b/src/components/app/templates/shortcuts/default.tsx
@@ -98,7 +98,8 @@ function DefaultEditorShortcuts({ sid }: Props) {
 						ev.preventDefault();
 						return dispatch(rehydrate());
 					}
-					return;
+					ev.preventDefault();
+					return Promise.resolve(dispatch(saveBeatmapContents({ songId: sid }))).then(() => window.location.reload());
 				}
 				case "Space": {
 					// If the user holds down the space, we don't want to register a bunch of play/pause events.

--- a/src/components/app/templates/shortcuts/default.tsx
+++ b/src/components/app/templates/shortcuts/default.tsx
@@ -76,6 +76,10 @@ function DefaultEditorShortcuts({ sid }: Props) {
 		{ wait: wait },
 	);
 
+	const handleRefresh = useCallback(() => {
+		dispatch(saveBeatmapContents({ songId: sid }));
+	}, [dispatch, sid]);
+
 	const handleKeyDown = useCallback(
 		(ev: KeyboardEvent) => {
 			if (isLoading) return;
@@ -98,8 +102,7 @@ function DefaultEditorShortcuts({ sid }: Props) {
 						ev.preventDefault();
 						return dispatch(rehydrate());
 					}
-					ev.preventDefault();
-					return Promise.resolve(dispatch(saveBeatmapContents({ songId: sid }))).then(() => window.location.reload());
+					return;
 				}
 				case "Space": {
 					// If the user holds down the space, we don't want to register a bunch of play/pause events.
@@ -251,6 +254,8 @@ function DefaultEditorShortcuts({ sid }: Props) {
 	useGlobalEventListener("keydown", handleKeyDown);
 	useGlobalEventListener("keyup", handleKeyUp);
 	useGlobalEventListener("wheel", handleWheel, { options: { passive: false } });
+
+	useGlobalEventListener("beforeunload", handleRefresh);
 
 	return null;
 }

--- a/src/components/app/templates/shortcuts/default.tsx
+++ b/src/components/app/templates/shortcuts/default.tsx
@@ -236,6 +236,7 @@ function DefaultEditorShortcuts({ sid }: Props) {
 
 	const handleWheel = useCallback(
 		(ev: WheelEvent) => {
+			ev.preventDefault();
 			if (isLoading) return;
 			if (!view) return;
 			if (activePrompt) return;
@@ -249,7 +250,7 @@ function DefaultEditorShortcuts({ sid }: Props) {
 
 	useGlobalEventListener("keydown", handleKeyDown);
 	useGlobalEventListener("keyup", handleKeyUp);
-	useGlobalEventListener("wheel", handleWheel, { options: { passive: true } });
+	useGlobalEventListener("wheel", handleWheel, { options: { passive: false } });
 
 	return null;
 }

--- a/src/components/scene/templates/visualization/index.tsx
+++ b/src/components/scene/templates/visualization/index.tsx
@@ -87,6 +87,8 @@ function MapVisualization({ sid, bid, beatDepth, surfaceDepth, interactive }: Pr
 		(event: ThreeEvent<PointerEvent>) => {
 			if (selectionMode) return;
 			if (isDispatchingEvent.current) return;
+			// ignore left click, since we don't want passthrough to take priority over placements
+			if (event.button === 0) return;
 
 			const intersects = raycaster.intersectObjects(scene.children, true);
 

--- a/src/components/ui/compositions/button.tsx
+++ b/src/components/ui/compositions/button.tsx
@@ -13,13 +13,13 @@ export interface ButtonProps extends ComponentProps<typeof Styled> {
 	loading?: boolean;
 	unfocusOnClick?: boolean;
 }
-export function Button({ colorPalette: color, loading, onClick, unfocusOnClick, asChild, children, ...rest }: ButtonProps) {
-	const handleClick = useCallback<MouseEventHandler<HTMLButtonElement>>(
+export function Button({ colorPalette: color, loading, onClickCapture, unfocusOnClick, asChild, children, ...rest }: ButtonProps) {
+	const handleClickCapture = useCallback<MouseEventHandler<HTMLButtonElement>>(
 		(event) => {
 			if (unfocusOnClick) event.currentTarget.blur();
-			if (onClick) onClick(event);
+			if (onClickCapture) onClickCapture(event);
 		},
-		[onClick, unfocusOnClick],
+		[onClickCapture, unfocusOnClick],
 	);
 
 	const colorPalette = useMemo(() => {
@@ -29,7 +29,7 @@ export function Button({ colorPalette: color, loading, onClick, unfocusOnClick, 
 	}, [color, rest.variant]);
 
 	return (
-		<Styled disabled={rest.disabled || loading} data-loading={loading} onClick={handleClick} className={css({ colorPalette: colorPalette })} {...rest}>
+		<Styled disabled={rest.disabled || loading} data-loading={loading} onClickCapture={handleClickCapture} className={css({ colorPalette: colorPalette })} {...rest}>
 			<ark.span asChild={asChild}>{children}</ark.span>
 			<Presence asChild present={!!loading} lazyMount unmountOnExit>
 				<Float placement={"middle-center"}>

--- a/src/components/ui/compositions/button.tsx
+++ b/src/components/ui/compositions/button.tsx
@@ -1,6 +1,6 @@
 import { ark } from "@ark-ui/react/factory";
 import { Presence } from "@ark-ui/react/presence";
-import { type ComponentProps, type MouseEventHandler, useCallback, useMemo } from "react";
+import { type ComponentProps, type KeyboardEvent, type MouseEvent, useCallback, useMemo } from "react";
 
 import { Button as Styled } from "$/components/ui/styled/button";
 import type { VirtualColorPalette } from "$/styles/types";
@@ -13,13 +13,12 @@ export interface ButtonProps extends ComponentProps<typeof Styled> {
 	loading?: boolean;
 	unfocusOnClick?: boolean;
 }
-export function Button({ colorPalette: color, loading, onClickCapture, unfocusOnClick, asChild, children, ...rest }: ButtonProps) {
-	const handleClickCapture = useCallback<MouseEventHandler<HTMLButtonElement>>(
-		(event) => {
+export function Button({ colorPalette: color, loading, unfocusOnClick, asChild, children, ...rest }: ButtonProps) {
+	const handleUnfocus = useCallback(
+		(event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>) => {
 			if (unfocusOnClick) event.currentTarget.blur();
-			if (onClickCapture) onClickCapture(event);
 		},
-		[onClickCapture, unfocusOnClick],
+		[unfocusOnClick],
 	);
 
 	const colorPalette = useMemo(() => {
@@ -29,7 +28,7 @@ export function Button({ colorPalette: color, loading, onClickCapture, unfocusOn
 	}, [color, rest.variant]);
 
 	return (
-		<Styled disabled={rest.disabled || loading} data-loading={loading} onClickCapture={handleClickCapture} className={css({ colorPalette: colorPalette })} {...rest}>
+		<Styled disabled={rest.disabled || loading} data-loading={loading} onClickCapture={handleUnfocus} onKeyDownCapture={handleUnfocus} className={css({ colorPalette: colorPalette })} {...rest}>
 			<ark.span asChild={asChild}>{children}</ark.span>
 			<Presence asChild present={!!loading} lazyMount unmountOnExit>
 				<Float placement={"middle-center"}>

--- a/src/components/ui/compositions/checkbox.tsx
+++ b/src/components/ui/compositions/checkbox.tsx
@@ -1,15 +1,23 @@
 import { type LucideProps, MinusIcon, XIcon } from "lucide-react";
-import { type ComponentProps, type ComponentType, forwardRef } from "react";
+import { type ComponentProps, type ComponentType, forwardRef, type KeyboardEvent, type MouseEvent, useCallback } from "react";
 
 import * as Builder from "$/components/ui/styled/checkbox";
 
 export interface CheckboxProps extends ComponentProps<typeof Builder.Root> {
 	icon?: ComponentType<LucideProps>;
+	unfocusOnClick?: boolean;
 }
-export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(({ icon: Icon = XIcon, children, ...rest }, ref) => {
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(({ icon: Icon = XIcon, children, unfocusOnClick, ...rest }, ref) => {
+	const handleUnfocus = useCallback(
+		(event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>) => {
+			if (unfocusOnClick) event.currentTarget.blur();
+		},
+		[unfocusOnClick],
+	);
+
 	return (
 		<Builder.Root {...rest}>
-			<Builder.Control>
+			<Builder.Control onClickCapture={handleUnfocus} onKeyDownCapture={handleUnfocus}>
 				<Builder.Indicator>
 					<Icon size={16} />
 				</Builder.Indicator>

--- a/src/components/ui/compositions/dialog.tsx
+++ b/src/components/ui/compositions/dialog.tsx
@@ -39,7 +39,7 @@ function Contents({ title, description, render, children }: DialogProps & PropsW
 
 export function Dialog({ children, ...rest }: Assign<ComponentProps<typeof Builder.Root>, DialogProps>) {
 	return (
-		<Builder.Root {...rest}>
+		<Builder.Root {...rest} modal={false}>
 			{children && (
 				<Builder.Trigger asChild>
 					<span>{children}</span>

--- a/src/components/ui/compositions/select.tsx
+++ b/src/components/ui/compositions/select.tsx
@@ -3,7 +3,7 @@ import type { CollectionItem, ListCollection } from "@ark-ui/react/collection";
 import { Portal } from "@ark-ui/react/portal";
 import type { SelectRootProps } from "@ark-ui/react/select";
 import { ChevronDownIcon } from "lucide-react";
-import type { PropsWithChildren } from "react";
+import { type KeyboardEvent, type MouseEvent, type PropsWithChildren, useCallback, useRef } from "react";
 
 import { ListCollectionFor } from "$/components/ui/atoms";
 import * as Builder from "$/components/ui/styled/select";
@@ -14,12 +14,22 @@ export interface SelectProps<T extends SelectItem> extends Assign<SelectRootProp
 	collection: ListCollection<T>;
 	size?: "sm" | "md";
 	placeholder?: string;
+	unfocusOnClick?: boolean;
 }
-export function Select<T extends SelectItem>({ collection, placeholder, children, ...rest }: SelectProps<T>) {
+export function Select<T extends SelectItem>({ collection, placeholder, children, unfocusOnClick, ...rest }: SelectProps<T>) {
+	const ref = useRef<HTMLDivElement>(null);
+
+	const handleUnfocus = useCallback(
+		(event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>) => {
+			if (unfocusOnClick) event.currentTarget.blur();
+		},
+		[unfocusOnClick],
+	);
+
 	return (
-		<Builder.Root collection={collection as ListCollection<SelectItem>} {...rest}>
+		<Builder.Root ref={ref} collection={collection as ListCollection<SelectItem>} {...rest} onKeyDown={(e) => e.stopPropagation()}>
 			<Builder.Control>
-				<Builder.Trigger>
+				<Builder.Trigger onClickCapture={handleUnfocus} onKeyDownCapture={handleUnfocus}>
 					{children && <Builder.Label>{children}</Builder.Label>}
 					<Builder.ValueText placeholder={placeholder} />
 					<Builder.Indicator>

--- a/src/components/ui/compositions/slider.tsx
+++ b/src/components/ui/compositions/slider.tsx
@@ -1,19 +1,27 @@
-import type { ComponentProps } from "react";
+import { type ComponentProps, type KeyboardEvent, type MouseEvent, useCallback } from "react";
 
 import { For } from "$/components/ui/atoms";
 import * as Builder from "$/components/ui/styled/slider";
 
 export interface SliderProps extends ComponentProps<typeof Builder.Root> {
 	marks?: Array<number>;
+	unfocusOnClick?: boolean;
 }
-export function Slider({ children, marks, ...rest }: SliderProps) {
+export function Slider({ children, marks, unfocusOnClick, ...rest }: SliderProps) {
+	const handleUnfocus = useCallback(
+		(event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>) => {
+			if (unfocusOnClick) event.currentTarget.blur();
+		},
+		[unfocusOnClick],
+	);
+
 	return (
 		<Builder.Root thumbAlignment="center" {...rest}>
 			<Builder.Control>
 				<Builder.Track>
 					<Builder.Range />
 				</Builder.Track>
-				<Builder.Thumb index={0}>
+				<Builder.Thumb index={0} onClickCapture={handleUnfocus} onKeyDownCapture={handleUnfocus}>
 					<Builder.HiddenInput />
 				</Builder.Thumb>
 				<Builder.MarkerGroup>

--- a/src/components/ui/compositions/switch.tsx
+++ b/src/components/ui/compositions/switch.tsx
@@ -1,12 +1,21 @@
-import type { ComponentProps } from "react";
+import { type ComponentProps, type KeyboardEvent, type MouseEvent, useCallback } from "react";
 
 import * as Builder from "$/components/ui/styled/switch";
 
-export interface SwitchProps extends ComponentProps<typeof Builder.Root> {}
-export function Switch({ children, ...rest }: SwitchProps) {
+export interface SwitchProps extends ComponentProps<typeof Builder.Root> {
+	unfocusOnClick?: boolean;
+}
+export function Switch({ children, unfocusOnClick, ...rest }: SwitchProps) {
+	const handleUnfocus = useCallback(
+		(event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>) => {
+			if (unfocusOnClick) event.currentTarget.blur();
+		},
+		[unfocusOnClick],
+	);
+
 	return (
 		<Builder.Root {...rest}>
-			<Builder.Control>
+			<Builder.Control onClickCapture={handleUnfocus} onKeyDownCapture={handleUnfocus}>
 				<Builder.Thumb />
 			</Builder.Control>
 			{children && <Builder.Label>{children}</Builder.Label>}

--- a/src/components/ui/compositions/tabs.tsx
+++ b/src/components/ui/compositions/tabs.tsx
@@ -1,6 +1,6 @@
 import type { CollectionItem, ListCollection } from "@ark-ui/react/collection";
 import type { UseTabsContext } from "@ark-ui/react/tabs";
-import type { ComponentProps, ReactNode } from "react";
+import { type ComponentProps, type KeyboardEvent, type MouseEvent, type ReactNode, useCallback } from "react";
 
 import { ListCollectionFor } from "$/components/ui/atoms";
 import * as Builder from "$/components/ui/styled/tabs";
@@ -15,8 +15,16 @@ export interface TabsItem extends CollectionItem {
 export interface TabsProps<T extends TabsItem> extends ComponentProps<typeof Builder.Root> {
 	collection: ListCollection<T>;
 	colorPalette?: VirtualColorPalette;
+	unfocusOnClick?: boolean;
 }
-export function Tabs<T extends TabsItem>({ collection, colorPalette = "pink", ...rest }: TabsProps<T>) {
+export function Tabs<T extends TabsItem>({ collection, colorPalette = "pink", unfocusOnClick, ...rest }: TabsProps<T>) {
+	const handleUnfocus = useCallback(
+		(event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>) => {
+			if (unfocusOnClick) event.currentTarget.blur();
+		},
+		[unfocusOnClick],
+	);
+
 	return (
 		<Builder.Root defaultValue={rest.defaultValue ?? collection.firstValue} {...rest}>
 			<Builder.List className={css({ colorPalette })}>
@@ -27,7 +35,7 @@ export function Tabs<T extends TabsItem>({ collection, colorPalette = "pink", ..
 						const label = collection.stringifyItem(item);
 						const disabled = collection.getItemDisabled(item);
 						return (
-							<Builder.Trigger key={value} value={value} disabled={disabled}>
+							<Builder.Trigger key={value} value={value} disabled={disabled} onClickCapture={handleUnfocus} onKeyDownCapture={handleUnfocus}>
 								{label}
 							</Builder.Trigger>
 						);

--- a/src/components/ui/compositions/toggle-group.tsx
+++ b/src/components/ui/compositions/toggle-group.tsx
@@ -1,5 +1,5 @@
 import type { CollectionItem, ListCollection } from "@ark-ui/react/collection";
-import type { ComponentProps } from "react";
+import { type ComponentProps, type MouseEventHandler, useCallback } from "react";
 
 import { ListCollectionFor } from "$/components/ui/atoms";
 import * as Builder from "$/components/ui/styled/toggle-group";
@@ -8,10 +8,18 @@ export interface ToggleItem extends CollectionItem {}
 
 export interface ToggleGroupProps<T extends ToggleItem> extends ComponentProps<typeof Builder.Root> {
 	collection: ListCollection<T>;
+	unfocusOnClick?: boolean;
 }
-export function ToggleGroup<T extends ToggleItem>({ collection, ...rest }: ToggleGroupProps<T>) {
+export function ToggleGroup<T extends ToggleItem>({ collection, unfocusOnClick, ...rest }: ToggleGroupProps<T>) {
+	const handleClickCapture = useCallback<MouseEventHandler<HTMLButtonElement>>(
+		(event) => {
+			if (unfocusOnClick) event.currentTarget.blur();
+		},
+		[unfocusOnClick],
+	);
+
 	return (
-		<Builder.Root {...rest}>
+		<Builder.Root {...rest} tabIndex={-1}>
 			<ListCollectionFor collection={collection}>
 				{(item) => {
 					const value = collection.getItemValue(item);
@@ -19,7 +27,7 @@ export function ToggleGroup<T extends ToggleItem>({ collection, ...rest }: Toggl
 					const label = collection.stringifyItem(item);
 					const disabled = collection.getItemDisabled(item);
 					return (
-						<Builder.Item key={value} value={value} disabled={disabled}>
+						<Builder.Item key={value} value={value} disabled={disabled} onClickCapture={handleClickCapture}>
 							{label}
 						</Builder.Item>
 					);

--- a/src/components/ui/compositions/toggle.tsx
+++ b/src/components/ui/compositions/toggle.tsx
@@ -1,9 +1,23 @@
-import type { ComponentProps } from "react";
+import { type ComponentProps, type MouseEventHandler, useCallback } from "react";
 
 import * as Builder from "$/components/ui/styled/toggle";
 
-interface Props extends ComponentProps<typeof Builder.Root> {}
+interface Props extends ComponentProps<typeof Builder.Root> {
+	unfocusOnClick?: boolean;
+}
 
-export function Toggle({ children, ...rest }: Props) {
-	return <Builder.Root {...rest}>{children}</Builder.Root>;
+export function Toggle({ children, unfocusOnClick, onClickCapture, ...rest }: Props) {
+	const handleClickCapture = useCallback<MouseEventHandler<HTMLButtonElement>>(
+		(event) => {
+			if (unfocusOnClick) event.currentTarget.blur();
+			if (onClickCapture) onClickCapture(event);
+		},
+		[onClickCapture, unfocusOnClick],
+	);
+
+	return (
+		<Builder.Root {...rest} onClickCapture={handleClickCapture}>
+			{children}
+		</Builder.Root>
+	);
 }

--- a/src/components/ui/compositions/toggle.tsx
+++ b/src/components/ui/compositions/toggle.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps, type MouseEventHandler, useCallback } from "react";
+import { type ComponentProps, type KeyboardEvent, type MouseEvent, useCallback } from "react";
 
 import * as Builder from "$/components/ui/styled/toggle";
 
@@ -6,17 +6,16 @@ interface Props extends ComponentProps<typeof Builder.Root> {
 	unfocusOnClick?: boolean;
 }
 
-export function Toggle({ children, unfocusOnClick, onClickCapture, ...rest }: Props) {
-	const handleClickCapture = useCallback<MouseEventHandler<HTMLButtonElement>>(
-		(event) => {
+export function Toggle({ children, unfocusOnClick, ...rest }: Props) {
+	const handleUnfocus = useCallback(
+		(event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>) => {
 			if (unfocusOnClick) event.currentTarget.blur();
-			if (onClickCapture) onClickCapture(event);
 		},
-		[onClickCapture, unfocusOnClick],
+		[unfocusOnClick],
 	);
 
 	return (
-		<Builder.Root {...rest} onClickCapture={handleClickCapture}>
+		<Builder.Root {...rest} onClickCapture={handleUnfocus} onKeyDownCapture={handleUnfocus}>
 			{children}
 		</Builder.Root>
 	);

--- a/src/components/ui/styled/toggle.tsx
+++ b/src/components/ui/styled/toggle.tsx
@@ -20,7 +20,7 @@ const recipe = sva({
 
 const { withProvider, withContext } = createStyleContext(recipe);
 
-export const Root = withProvider(Toggle.Root, "root", { defaultProps: { onClickCapture: (e) => e.currentTarget.blur() } });
+export const Root = withProvider(Toggle.Root, "root");
 export const Indicator = withContext(Toggle.Indicator, "indicator");
 
 export { ToggleContext as Context } from "@ark-ui/react/toggle";

--- a/src/components/ui/styled/toggle.tsx
+++ b/src/components/ui/styled/toggle.tsx
@@ -20,7 +20,7 @@ const recipe = sva({
 
 const { withProvider, withContext } = createStyleContext(recipe);
 
-export const Root = withProvider(Toggle.Root, "root");
+export const Root = withProvider(Toggle.Root, "root", { defaultProps: { onClickCapture: (e) => e.currentTarget.blur() } });
 export const Indicator = withContext(Toggle.Indicator, "indicator");
 
 export { ToggleContext as Context } from "@ark-ui/react/toggle";

--- a/src/helpers/item.helpers.ts
+++ b/src/helpers/item.helpers.ts
@@ -17,12 +17,22 @@ export function nudgeItem<T extends { time: number }>(item: T, direction: "forwa
 	} as Partial<T>;
 }
 
+function isExtendedCoordinate(x: number) {
+	return x >= 1000 || x <= -1000;
+}
+function deserializeCoordinate(x: number) {
+	return isExtendedCoordinate(x) ? x / 1000 + (x > 0 ? -1 : 1) : x;
+}
+function serializeCoordinate(x: number, extensions?: boolean) {
+	if (extensions) return (x >= 0 ? x + 1 : x - 1) * 1000;
+	return x;
+}
+
 function mirrorCoordinate(coordinate: number, count: number, offset?: number) {
-	const fromExtended = (x: number) => (x >= 1000 || x <= -1000 ? x / 1000 + (x > 0 ? -1 : 1) : x);
-	const value = fromExtended(coordinate);
+	const value = deserializeCoordinate(coordinate);
 	const axis = (count - 1) / 2;
-	const mirrored = axis - value + axis + (offset ? 1 - fromExtended(offset ?? 0) : 0);
-	return (mirrored >= 0 ? mirrored + 1 : mirrored - 1) * 1000;
+	const mirrored = axis - value + axis + (offset ? 1 - deserializeCoordinate(offset ?? 0) : 0);
+	return serializeCoordinate(mirrored, isExtendedCoordinate(coordinate));
 }
 
 export function mirrorItem<T extends { posX?: number; posY?: number; color?: NoteColor; direction?: number }>(item: T, axis: "horizontal" | "vertical", grid?: IGrid, offset?: number) {

--- a/src/helpers/item.helpers.ts
+++ b/src/helpers/item.helpers.ts
@@ -1,4 +1,5 @@
-import { mirrorNoteColor, mirrorNoteDirectionHorizontally, mirrorNoteDirectionVertically, type NoteColor } from "bsmap";
+import { mirrorNoteColor, mirrorNoteDirectionHorizontally, mirrorNoteDirectionVertically } from "bsmap";
+import type { wrapper } from "bsmap/types";
 
 import { DEFAULT_NUM_COLS, DEFAULT_NUM_ROWS } from "$/constants";
 import type { IGrid } from "$/types";
@@ -28,21 +29,24 @@ function serializeCoordinate(x: number, extensions?: boolean) {
 	return x;
 }
 
-function mirrorCoordinate(coordinate: number, count: number, offset?: number) {
+export function mirrorCoordinate(coordinate: number, count: number, offset?: number) {
 	const value = deserializeCoordinate(coordinate);
 	const axis = (count - 1) / 2;
 	const mirrored = axis - value + axis + (offset ? 1 - deserializeCoordinate(offset ?? 0) : 0);
 	return serializeCoordinate(mirrored, isExtendedCoordinate(coordinate));
 }
 
-export function mirrorItem<T extends { posX?: number; posY?: number; color?: NoteColor; direction?: number }>(item: T, axis: "horizontal" | "vertical", grid?: IGrid, offset?: number) {
-	const resolveDirection = axis === "horizontal" ? mirrorNoteDirectionHorizontally : mirrorNoteDirectionVertically;
-	const color = item.color !== undefined ? item.color : undefined;
-	const direction = item.direction !== undefined ? item.direction : undefined;
+export function mirrorGridObjectProperties<T extends wrapper.IWrapGridObject>(item: T, axis: "horizontal" | "vertical", grid?: IGrid, offset?: number): Partial<T> {
 	return {
-		posX: axis === "horizontal" && item.posX !== undefined ? mirrorCoordinate(item.posX, DEFAULT_NUM_COLS, offset) : item.posX,
-		posY: axis === "vertical" && item.posY !== undefined ? mirrorCoordinate(item.posY, grid?.numRows ?? DEFAULT_NUM_ROWS, offset) : item.posY,
-		color: axis === "horizontal" && color !== undefined ? mirrorNoteColor(color) : item.color,
-		direction: direction !== undefined ? resolveDirection(direction) : undefined,
+		posX: axis === "horizontal" ? mirrorCoordinate(item.posX, DEFAULT_NUM_COLS, offset) : item.posX,
+		posY: axis === "vertical" ? mirrorCoordinate(item.posY, grid?.numRows ?? DEFAULT_NUM_ROWS, offset) : item.posY,
+	} as Partial<T>;
+}
+
+export function mirrorBaseNoteProperties<T extends wrapper.IWrapBaseNote>(item: T, axis: "horizontal" | "vertical"): Partial<T> {
+	const resolveDirection = axis === "horizontal" ? mirrorNoteDirectionHorizontally : mirrorNoteDirectionVertically;
+	return {
+		color: axis === "horizontal" ? mirrorNoteColor(item.color) : item.color,
+		direction: resolveDirection(item.direction),
 	} as Partial<T>;
 }

--- a/src/helpers/song.helpers.ts
+++ b/src/helpers/song.helpers.ts
@@ -1,4 +1,4 @@
-import { slugify } from "@std/text/unstable-slugify";
+import { toPascalCase } from "@std/text/to-pascal-case";
 import { CharacteristicName, DifficultyName } from "bsmap/types";
 
 import { DEFAULT_GRID } from "$/constants";
@@ -7,8 +7,11 @@ import { deepAssign } from "$/utils";
 import { deriveColorSchemeFromEnvironment } from "./colors.helpers";
 import { patchEnvironmentName } from "./packaging.helpers";
 
-export function resolveSongId(x: Pick<App.ISong, "name">): string {
-	return slugify(x.name);
+export function createSongId(x: Pick<App.ISong, "name">): string {
+	return toPascalCase(x.name);
+}
+export function resolveSongId(x: Pick<App.ISong, "id">): string {
+	return x.id.toString();
 }
 export function resolveBeatmapId(x: Pick<App.IBeatmap, "characteristic" | "difficulty">): string {
 	if (x.characteristic !== "Standard") return `${x.difficulty}${x.characteristic}`;

--- a/src/routes/editor/layout.tsx
+++ b/src/routes/editor/layout.tsx
@@ -10,7 +10,7 @@ import { MDXContent } from "$/components/ui/atoms";
 import { List, Text } from "$/components/ui/compositions";
 import { store } from "$/setup";
 import { dismissPrompt, leaveEditor, startLoadingMap } from "$/store/actions";
-import { selectAnnouncements } from "$/store/selectors";
+import { selectAllEntities, selectAnnouncements } from "$/store/selectors";
 import { prompts } from "$:content";
 import { css } from "$:styled-system/css";
 import { styled } from "$:styled-system/jsx";
@@ -57,7 +57,9 @@ export const Route = createFileRoute("/_/edit/$sid/$bid/_")({
 		}
 	},
 	onLeave: async ({ params }) => {
-		await Promise.resolve(store.dispatch(leaveEditor({ songId: params.sid, beatmapId: params.bid })));
+		const state = store.getState();
+		const entities = selectAllEntities(state);
+		await Promise.resolve(store.dispatch(leaveEditor({ songId: params.sid, beatmapId: params.bid, entities })));
 	},
 });
 

--- a/src/services/packaging.service.ts
+++ b/src/services/packaging.service.ts
@@ -10,7 +10,7 @@ import { convertMillisecondsToBeats, deriveAudioDataFromFile } from "$/helpers/a
 import { serializeCustomBookmark } from "$/helpers/bookmarks.helpers";
 import { deserializeInfoContents } from "$/helpers/packaging.helpers";
 import type { ImplicitVersion } from "$/helpers/serialization.helpers";
-import { getSelectedBeatmap, resolveBeatmapIdFromFilename, resolveLightshowIdFromFilename, resolveSongId } from "$/helpers/song.helpers";
+import { createSongId, getSelectedBeatmap, resolveBeatmapIdFromFilename, resolveLightshowIdFromFilename } from "$/helpers/song.helpers";
 import { filestore } from "$/setup";
 import type { App, IEntityMap, SongId } from "$/types";
 import { deepAssign, yieldValue } from "$/utils";
@@ -168,7 +168,7 @@ export async function processImportedMap(zipFile: Uint8Array, options: { current
 	// parse the wrapper into the editor form
 	const song = deserializeInfoContents(info, { readonly: options.readonly });
 
-	const songId = resolveSongId(song);
+	const songId = createSongId(song);
 
 	// save the info data (Not 100% sure that this is necessary, but better to have and not need)
 	await filestore.saveInfoContents(songId, info);
@@ -257,6 +257,7 @@ export async function processImportedMap(zipFile: Uint8Array, options: { current
 
 	return {
 		...song,
+		id: songId,
 		selectedDifficulty: getSelectedBeatmap(song),
 		createdAt: Date.now(),
 	};

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -74,7 +74,7 @@ export const downloadMapFiles = createAction("downloadMap", (args: { songId: Son
 	return { payload: { ...args } };
 });
 
-export const leaveEditor = createAction("leaveEditor", (args: { songId: SongId; beatmapId: BeatmapId }) => {
+export const leaveEditor = createAction("leaveEditor", (args: { songId: SongId; beatmapId: BeatmapId; entities: Partial<App.IBeatmapEntities> }) => {
 	return { payload: { ...args } };
 });
 

--- a/src/store/features/entities/beatmap/bombs.slice.ts
+++ b/src/store/features/entities/beatmap/bombs.slice.ts
@@ -1,7 +1,7 @@
 import { createEntityAdapter, createSlice, type EntityId, isAnyOf } from "@reduxjs/toolkit";
 import { createBombNote, sortObjectFn } from "bsmap";
 
-import { mirrorItem, nudgeItem, resolveTimeForItem } from "$/helpers/item.helpers";
+import { mirrorGridObjectProperties, nudgeItem, resolveTimeForItem } from "$/helpers/item.helpers";
 import { resolveNoteId } from "$/helpers/notes.helpers";
 import {
 	addSong,
@@ -123,9 +123,15 @@ const slice = createSlice({
 		builder.addCase(mirrorSelection, (state, action) => {
 			const { axis, grid } = action.payload;
 			const entities = selectAllSelected(state);
-			return adapter.updateMany(
+			adapter.removeMany(
 				state,
-				entities.map((x) => ({ id: adapter.selectId(x), changes: mirrorItem(x, axis, grid) })),
+				entities.map((x) => adapter.selectId(x)),
+			);
+			return adapter.addMany(
+				state,
+				entities.map((x) => {
+					return { ...x, ...mirrorGridObjectProperties(x, axis, grid, 0) };
+				}),
 			);
 		});
 		builder.addCase(nudgeSelection.fulfilled, (state, action) => {

--- a/src/store/features/entities/beatmap/notes.slice.ts
+++ b/src/store/features/entities/beatmap/notes.slice.ts
@@ -1,7 +1,7 @@
 import { createEntityAdapter, createSlice, type EntityId, isAnyOf } from "@reduxjs/toolkit";
 import { createColorNote, mirrorNoteColor, sortObjectFn } from "bsmap";
 
-import { mirrorItem, nudgeItem, resolveTimeForItem } from "$/helpers/item.helpers";
+import { mirrorBaseNoteProperties, mirrorGridObjectProperties, nudgeItem, resolveTimeForItem } from "$/helpers/item.helpers";
 import { resolveNoteId } from "$/helpers/notes.helpers";
 import {
 	addSong,
@@ -131,9 +131,15 @@ const slice = createSlice({
 		builder.addCase(mirrorSelection, (state, action) => {
 			const { axis, grid } = action.payload;
 			const entities = selectAllSelected(state);
-			return adapter.updateMany(
+			adapter.removeMany(
 				state,
-				entities.map((x) => ({ id: adapter.selectId(x), changes: mirrorItem(x, axis, grid) })),
+				entities.map((x) => adapter.selectId(x)),
+			);
+			return adapter.addMany(
+				state,
+				entities.map((x) => {
+					return { ...x, ...mirrorGridObjectProperties(x, axis, grid, 0), ...mirrorBaseNoteProperties(x, axis) };
+				}),
 			);
 		});
 		builder.addCase(nudgeSelection.fulfilled, (state, action) => {

--- a/src/store/features/entities/beatmap/obstacles.slice.ts
+++ b/src/store/features/entities/beatmap/obstacles.slice.ts
@@ -1,7 +1,7 @@
 import { type AsyncThunkPayloadCreator, createEntityAdapter, type EntityId, isAnyOf, type Update } from "@reduxjs/toolkit";
 import { createObstacle, sortObjectFn } from "bsmap";
 
-import { mirrorItem, nudgeItem, resolveTimeForItem } from "$/helpers/item.helpers";
+import { mirrorGridObjectProperties, nudgeItem, resolveTimeForItem } from "$/helpers/item.helpers";
 import { resolveObstacleId } from "$/helpers/obstacles.helpers";
 import { addObstacle, addSong, cutSelection, deselectAllEntities, deselectAllEntitiesOfType, leaveEditor, loadBeatmapEntities, mirrorSelection, nudgeSelection, pasteSelection, removeAllSelectedObjects, selectAllEntities, selectAllEntitiesInRange, startLoadingMap } from "$/store/actions";
 import { createSelectedEntitiesSelector, createSlice } from "$/store/helpers";
@@ -138,9 +138,15 @@ const slice = createSlice({
 			const { axis, grid } = action.payload;
 			if (axis === "vertical") return state;
 			const entities = selectAllSelected(state);
-			return adapter.updateMany(
+			adapter.removeMany(
 				state,
-				entities.map((x) => ({ id: adapter.selectId(x), changes: mirrorItem(x, "horizontal", grid, x.width) })),
+				entities.map((x) => adapter.selectId(x)),
+			);
+			return adapter.addMany(
+				state,
+				entities.map((x) => {
+					return { ...x, ...mirrorGridObjectProperties(x, axis, grid, x.width) };
+				}),
 			);
 		});
 		builder.addCase(nudgeSelection.fulfilled, (state, action) => {

--- a/src/store/features/songs.slice.ts
+++ b/src/store/features/songs.slice.ts
@@ -22,8 +22,7 @@ const fetchContentsFromFile: AsyncThunkPayloadCreator<{ songId: SongId; songData
 		const { readonly } = args.options;
 		const archive = await args.file.arrayBuffer();
 		const songData = await processImportedMap(new Uint8Array(archive), args.options);
-		const songId = resolveSongId({ name: songData.name });
-		return api.fulfillWithValue({ songId, songData: { ...songData, demo: readonly } });
+		return api.fulfillWithValue({ songId: songData.id, songData: { ...songData, demo: readonly } });
 	} catch (e) {
 		return api.rejectWithValue(e);
 	}
@@ -95,7 +94,7 @@ const slice = createSlice({
 					return {
 						payload: {
 							songId: songId,
-							songData: { ...rest },
+							songData: { ...rest, id: songId.toString() },
 							beatmapId: resolveBeatmapId({ characteristic: selectedCharacteristic, difficulty: selectedDifficulty }),
 							beatmapData: { characteristic: selectedCharacteristic, difficulty: selectedDifficulty, mappers, lighters: mappers },
 							songFile,

--- a/src/store/middleware/backup.middleware.ts
+++ b/src/store/middleware/backup.middleware.ts
@@ -1,24 +1,34 @@
 import { createListenerMiddleware, isAnyOf, type PayloadAction } from "@reduxjs/toolkit";
 
+import type { BeatmapFilestore } from "$/services/file.service";
 import { downloadMapFiles, leaveEditor, saveBeatmapContents, updateBeatmap, updateSong } from "$/store/actions";
 import type { RootState } from "$/store/setup";
-import type { BeatmapId, SongId } from "$/types";
+import type { App, BeatmapId, SongId } from "$/types";
 import type { createAutosaveWorker } from "$/workers";
 import { selectActiveBeatmapId } from "../selectors";
 
 interface Options {
+	filestore: BeatmapFilestore;
 	worker: ReturnType<typeof createAutosaveWorker>;
 }
 export default function createBackupMiddleware({ worker }: Options) {
 	const instance = createListenerMiddleware<RootState>();
 
 	instance.startListening({
-		matcher: isAnyOf(saveBeatmapContents, downloadMapFiles, leaveEditor),
+		matcher: isAnyOf(saveBeatmapContents, downloadMapFiles),
 		effect: async (action: PayloadAction<{ songId: SongId }>, api) => {
 			const { songId } = action.payload;
 			const state = api.getState();
 			const beatmapId = selectActiveBeatmapId(state);
 			await worker.save(state, songId, beatmapId);
+		},
+	});
+	instance.startListening({
+		matcher: isAnyOf(leaveEditor),
+		effect: async (action: PayloadAction<{ songId: SongId; beatmapId: BeatmapId; entities: Partial<App.IBeatmapEntities> }>, api) => {
+			const { songId, beatmapId, entities } = action.payload;
+			const state = api.getState();
+			await worker.save(state, songId, beatmapId, entities);
 		},
 	});
 	instance.startListening({

--- a/src/store/middleware/demo.middleware.ts
+++ b/src/store/middleware/demo.middleware.ts
@@ -1,7 +1,7 @@
 import { createListenerMiddleware } from "@reduxjs/toolkit";
 
 import { demoFileUrl } from "$/assets";
-import { getSelectedBeatmap, resolveSongId } from "$/helpers/song.helpers";
+import { getSelectedBeatmap } from "$/helpers/song.helpers";
 import { router } from "$/index";
 import { addSongFromFile, loadDemoMap } from "$/store/actions";
 import type { RootState } from "$/store/setup";
@@ -16,10 +16,9 @@ export default function createDemoMiddleware() {
 		actionCreator: loadDemoMap,
 		effect: async (_, api) => {
 			const blob = await fetch(demoFileUrl).then((response) => response.blob());
-			const { songData } = await api.dispatch(addSongFromFile({ file: blob, options: { readonly: true } })).unwrap();
-			const sid = resolveSongId({ name: songData.name });
+			const { songId: sid, songData } = await api.dispatch(addSongFromFile({ file: blob, options: { readonly: true } })).unwrap();
 			const bid = getSelectedBeatmap(songData);
-			router.navigate({ to: "/edit/$sid/$bid/notes", params: { sid, bid: bid.toString() } });
+			router.navigate({ to: "/edit/$sid/$bid/notes", params: { sid: sid.toString(), bid: bid.toString() } });
 		},
 	});
 

--- a/src/store/middleware/index.ts
+++ b/src/store/middleware/index.ts
@@ -26,7 +26,7 @@ export function createAllSharedMiddleware({ filestore, autosaveWorker }: Options
 	const audioMiddleware = createAudioMiddleware({ filestore });
 	const fileMiddleware = createFileMiddleware({ filestore });
 	const downloadMiddleware = createPackagingMiddleware({ filestore });
-	const backupMiddleware = createBackupMiddleware({ worker: autosaveWorker });
+	const backupMiddleware = createBackupMiddleware({ filestore, worker: autosaveWorker });
 	const demoMiddleware = createDemoMiddleware();
 	const historyMiddleware = createHistoryMiddleware();
 

--- a/src/types/beatmap/app/info.ts
+++ b/src/types/beatmap/app/info.ts
@@ -31,6 +31,7 @@ export interface IBeatmap {
 }
 
 export interface ISong {
+	id: EntityId;
 	name: string;
 	subName: string;
 	artistName: string;


### PR DESCRIPTION
This is a hotfix release aiming to fix critical bugs and unstable behaviors from the last update.

## Breaking Changes

- The state/file idb stores have both been migrated to version `4` to fix indexing issues for song data.
  - All locally-stored songs will now possess a dedicated `id` property to prevent file associations from breaking if/when the song title is updated.
  - All songs will now be indexed using PascalCase (i.e. `only-now` -> `OnlyNow`) so longer titles can be compacted within the URL more reliably. This will be applied retroactively to all pre-existing maps, so if you have any URLs that are bookmarked, you will need to update them to their PascalCase equivalents.

> [!warning]
> While migrations have been implemented to minimize the chance of breakage, it's highly recommended that you **always keep backups of your maps on your device** before moving to a new update in order to minimize the surface area of potential data loss in the event something goes awry.

## Bugfixes

- The `LEAVE_EDITOR` action will now properly save the current beatmap contents before leaving the editor view. (#33)
- Refreshing the page will now try to save the current map contents. (#33)
- The mirror functionality has been adjusted to fix faulty behaviors:
  - Mirroring will now respect the original map data, as opposed to always converting values to extended ranges. (#26)
  - Mirroring symmetrical patterns will now batch entity updates to prevent cases where mirrored objects can overwrite other objects. (#35)
- The passthrough behavior for the placement grid will now ignore left-clicks for more intuitive event priority. (#36)
- Certain UI elements will now unfocus when interacted with to mitigate conflicts with global hotkeys. (#34)
